### PR TITLE
Fixing OpenVAS Scanner Image guide.

### DIFF
--- a/OPENVAS_IMAGE/README.md
+++ b/OPENVAS_IMAGE/README.md
@@ -53,7 +53,7 @@ With Image TAG after `21.4.0-v5`
 
    Scanner Name: **This can be anything you want**
    Scanner ID: **generated id from remote openvas scanner**
-   Scanner public key: **private key from scanner**
+   Scanner public key: **public key from scanner**
 
    You will receive a confirmation that the scanner has been added
 


### PR DESCRIPTION
This pull request contains fix for issue #16.

At page that describes [OpenVAS Scanner Image](https://securecompliance.gitbook.io/projects/openvas_image) one of the deployment steps is adding an OpenVAS scanner to GVM via add-scanner.sh script. Description of that process (quote below) is confusing. We need to pass scanner's private key when script (add-scanner.sh) asks for public.

> Scanner Name: This can be anything you want Scanner ID: generated id from remote openvas scanner Scanner public key: private key from scanner

I passed scanner's public key to add-scanner.sh script and it worked. So I changed "private" to "public" in the description of the process.