### PR TITLE
Adding Squid proxy env variables.

### DIFF
--- a/OPENVAS_IMAGE/README.md
+++ b/OPENVAS_IMAGE/README.md
@@ -6,10 +6,11 @@ After starting the remote scanner, you will find the scanner\'s Public Key and t
 
 ##### The following are variables that can be set/modified using the `--env` option
 
-| Name           | Description                            | Default Value      |
-| -------------- | -------------------------------------- | ------------------ |
-| MASTER_ADDRESS | IP or Hostname of the GVM container    | (No default value) |
-| MASTER_PORT    | SSH server port from the GVM container | 22                 |
+| Name           | Description                                                             | Default Value      |
+| -------------- | ----------------------------------------------------------------------- | ------------------ |
+| MASTER_ADDRESS | IP or Hostname of the GVM container                                     | (No default value) |
+| MASTER_PORT    | SSH server port from the GVM container                                  | 22                 |
+| RSYNC_PROXY    | Optional Rsync proxy. Use 127.0.0.1:3128 to use GVM-Docker Squid proxy  | (No default value) |
 
 Steps to deploy remote scanner:
 

--- a/VARIABLES/README.md
+++ b/VARIABLES/README.md
@@ -35,6 +35,7 @@ These settings can be set in the docker command line with the --env parameter, o
 | `DB_PASSWORD` | This sets the postgres DB password                           | random        |
 | `DB_PASSWORD_FILE` | Default no password file for Docker Swarm Secrets - if set DB_PASSWORD is ignored |         |
 | `SSHD`        | This needs to be set to true if you are using the remote scanner    | false         |
+| `SQUID`       | Squid (rsync) proxy to start for remote scanner updates             | false         |
 | `TZ`          | Timezone name for a list look here: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones | UTC           |
 | `RELAYHOST`   | The IP address or hostname to send emails through.           | 127.17.0.1|
 | `SMTPPORT`    | The TCP port for the RELAYHOST                               | 25 |


### PR DESCRIPTION
Certain restricted environments have no internet connectivity and updating the image is problematic in those environments with rsync.

The OpenVAS image could use the existing SSH tunnel (forward a local port next to the unix socket) to access a Squid proxy running on the main GVM instance. Starting the proxy would be optional and in case it is not started, it wouldn't be possible to access it from the OpenVAS.

## Summary

Adding Squid proxy env variables to documentation.

### Fixed Bug/Issues solved:

Created issues: #16 in OpenVAS-Docker and #344 in GVM-Docker.
https://github.com/Secure-Compliance-Solutions-LLC/OpenVAS-Docker/issues/16
https://github.com/Secure-Compliance-Solutions-LLC/GVM-Docker/issues/344
